### PR TITLE
Add TELEGRAM_GROUP_INVITE_LINK env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -355,6 +355,7 @@ TOGETHER_API_KEY=             # Together API Key
 
 # Hats Protocol
 HAT_ID=
+TELEGRAM_GROUP_INVITE_LINK=
 
 # CoinMarketCap / CMC
 COINMARKETCAP_API_KEY=

--- a/packages/plugin-hats-test/src/actions/join_group_chat.ts
+++ b/packages/plugin-hats-test/src/actions/join_group_chat.ts
@@ -172,8 +172,12 @@ export const joinGroupChat: Action = {
                 throw new Error("Failed to mint hat for chat access!");
             }
 
+            const TELEGRAM_GROUP_INVITE_LINK = runtime.getSetting(
+                "TELEGRAM_GROUP_INVITE_LINK"
+            );
+
             const callbackData: Content = {
-                text: `You have successfully minted the hat that allows you to access the private chat!`,
+                text: `You have successfully minted the hat that allows you to access the private chat! The invite link is here: ${TELEGRAM_GROUP_INVITE_LINK}`,
                 action: "JOIN_GROUP_CHAT_RESPONSE",
                 source: message.content.source,
                 attachments: [],


### PR DESCRIPTION
Adds a `TELEGRAM_GROUP_INVITE_LINK` env for the `plugin-hats-test` plugin